### PR TITLE
Fix notice in functions.php when saving mappings

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -168,8 +168,10 @@ class Capsule_Client {
 					break;
 				case 'save_mapping':
 					if (wp_verify_nonce($_POST['_save_mapping_nonce'], '_cap_client_save_mapping')) {
-						$this->save_mapping($_POST['cap_client_mapping']);
+						if ( ! empty( $_POST['cap_client_mapping'] ) )
+							$this->save_mapping( $_POST['cap_client_mapping'] );
 					}
+					break;
 				default:
 					break;
 			}


### PR DESCRIPTION
If you save mappings without selecting any project it throws a notice because $_POST['cap_client_mapping'] doesn't exist. Also it was missing a break; for that select case.
